### PR TITLE
feat: Store artifacts to store

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,38 @@
 npm install screwdriver-artifact-bookend
 ```
 
+## Functionality
+
+Store all the artifacts saved in the Artifacts Directory to the build folder in the Store, to make sure they're not all erased when the build is complete. This bookend currently acts only as a teardown plugin. All artifacts files/folders are written to Store on teardown.
+
+This is a default plugin that is set in the default.yaml (https://github.com/screwdriver-cd/screwdriver/blob/master/config/default.yaml) under the bookends section.
+
+For example, if `$SD_ARTIFACTS_DIR` is set as `/sd/workspace/artifacts` and the user creates within that directory:
+
+```
+/sd/workspace/artifacts
+--first_dir
+----first_file.txt
+----second_file.txt
+--second_dir
+----third_file.txt
+----fourth_file.txt
+--fifth_file.txt
+```
+
+Then in Store:
+
+```
+https://{store-uri}/logs.screwdriver.cd/builds/<BUILD_ID>-ARTIFACTS
+--first_dir
+----first_file.txt
+----second_file.txt
+--second_dir
+----third_file.txt
+----fourth_file.txt
+--fifth_file.txt
+```
+
 ## Testing
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -1,0 +1,44 @@
+'use strict';
+
+const { BookendInterface } = require('screwdriver-build-bookend');
+const ARTIFACTS_DIR_SUFFIX = 'ARTIFACTS';
+
+class ArtifactBookend extends BookendInterface {
+    /**
+     * Constructor for ArtifactBookend
+     * @method constructor
+     * @param  {Object}    config Configuration
+     * @return {ArtifactBookend}
+     */
+    constructor(storeUrl) {
+        super();
+        this.storeUrl = storeUrl;
+        this.teardownCommands = [
+            'cd $SD_ARTIFACTS_DIR',
+            'find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" ' +
+            '-H "Content-Type: text/plain" -X ' +
+            `PUT ${this.storeUrl}/$SD_BUILD_ID/${ARTIFACTS_DIR_SUFFIX}/{} -T {} \\;`
+        ];
+    }
+
+    /**
+     * Gives the commands needed for setting up Artifact Storage before the build starts.
+     * Currently, there is nothing to set up
+     * @method getSetupCommand
+     * @return {Promise}           Resolves to an empty string
+     */
+    getSetupCommand() {
+        return Promise.resolve('');
+    }
+
+    /**
+     * Gives the commands needed for storing artifacts after a build completes.
+     * @method getTeardownCommand
+     * @return {Promise}           Resolves to a string that represents the commmand to execute
+     */
+    getTeardownCommand() {
+        return Promise.resolve(this.teardownCommands.join(' && '));
+    }
+}
+
+module.exports = ArtifactBookend;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "eslint-config-screwdriver": "^2.0.9",
     "jenkins-mocha": "^3.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "screwdriver-build-bookend": "^2.1.1"
+  },
   "release": {
     "debug": false,
     "verifyConditions": {

--- a/test/data/commands.txt
+++ b/test/data/commands.txt
@@ -1,0 +1,1 @@
+cd $SD_ARTIFACTS_DIR && find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/$SD_BUILD_ID/ARTIFACTS/{} -T {} \;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,9 +1,38 @@
+/* Inline JSHint configuration for Mocha globals. */
+/* global describe, it, beforeEach */ // All Mocha globals.
+
 'use strict';
 
 const assert = require('chai').assert;
+const ArtifactBookend = require('..');
+const fs = require('fs');
+const path = require('path');
 
 describe('index test', () => {
-    it('fails', () => {
-        assert.isTrue(false);
+    let bookend;
+
+    beforeEach(() => {
+        bookend = new ArtifactBookend('https://store.screwdriver.cd');
     });
+
+    it('constructs', () => {
+        assert.ok(bookend);
+        assert.property(bookend, 'getSetupCommand');
+        assert.property(bookend, 'getTeardownCommand');
+    });
+
+    it('getTeardownCommand', () => {
+        const commandsPath = path.resolve(__dirname, './data/commands.txt');
+        const commands = fs.readFileSync(commandsPath, 'utf8').replace('\n', '');
+
+        return bookend.getTeardownCommand().then(result =>
+            assert.deepEqual(result, commands)
+        );
+    });
+
+    it('getSetupCommand', () =>
+        bookend.getSetupCommand().then((result) => {
+            assert.strictEqual(result, '');
+        })
+    );
 });


### PR DESCRIPTION
Store all the artifacts saved in the Artifacts Directory to Store, to make sure they're not all erased when the build is complete.

This includes new directories that are made.

For example, if `SD_ARTIFACTS_DIR=/sd/workspace/artifacts`

And the user creates within that directory:

```
/sd/workspace/artifacts
--first_dir
----first_file.txt
----second_file.txt
--second_dir
----third_file.txt
----fourth_file.txt
--fifth_file.txt
```

Then in Store:

```
/logs.screwdriver.cd/builds/<BUILD_ID>-ARTIFACTS
--first_dir
----first_file.txt
----second_file.txt
--second_dir
----third_file.txt
----fourth_file.txt
--fifth_file.txt
```

Related: https://github.com/screwdriver-cd/screwdriver/issues/458