### PR TITLE
feat(468): Output manifest.txt of artifacts directory

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ class ArtifactBookend extends BookendInterface {
         this.storeUrl = storeUrl;
         this.teardownCommands = [
             'cd $SD_ARTIFACTS_DIR',
+            'find . -print > manifest.txt',
             'find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" ' +
             '-H "Content-Type: text/plain" -X ' +
             `PUT ${this.storeUrl}/v1/builds/$SD_BUILD_ID/${ARTIFACTS_DIR_SUFFIX}/{} -T {} \\;`

--- a/test/data/commands.txt
+++ b/test/data/commands.txt
@@ -1,1 +1,1 @@
-cd $SD_ARTIFACTS_DIR && find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/{} -T {} \;
+cd $SD_ARTIFACTS_DIR && find . -print > manifest.txt && find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/{} -T {} \;


### PR DESCRIPTION
Within the teardown commands that stores Artifacts to store, also output and store a `manifest.txt` file that lists all files and folders within the artifacts directory, to be parsed and displayed by the UI.

For example, a manifest.txt file may look like:

```
.
./coverage
./coverage/coverage.json
./coverage/lcov-report
./coverage/lcov-report/artifact-bookend
./coverage/lcov-report/artifact-bookend/index.html
./coverage/lcov-report/artifact-bookend/index.js.html
./coverage/lcov-report/base.css
./coverage/lcov-report/index.html
./coverage/lcov-report/prettify.css
./coverage/lcov-report/prettify.js
./coverage/lcov-report/sort-arrow-sprite.png
./coverage/lcov-report/sorter.js
./coverage/lcov.info
./test
./test/xunit.xml
```

The `manifest.txt` would be in the ARTIFACTS directory within any build in the Store. Thus, it can be accessed using a URL such as:

https://store.screwdriver.cd/v1/builds/1/ARTIFACTS/manifest.txt

To fetch one of the files within the ARTIFACTS, you could use the paths given in the manifest and hit a path like:

https://store.screwdriver.cd/v1/builds/1/ARTIFACTS/test/xunit.xml

Tied to issue: screwdriver-cd/screwdriver#468