### PR TITLE
fix: Ensure relative path of file in PUT URL does not contain ./

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,0 +1,3 @@
+cd $SD_ARTIFACTS_DIR
+find . -print > manifest.txt
+find . -type f -exec sh -c 'f=${1/#\.\/}; curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT $STORE_URL/v1/builds/$SD_BUILD_ID/$ARTIFACTS_DIR_SUFFIX/$f -T ./$f' -- {} \;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
+const fs = require('fs');
+const path = require('path');
 const { BookendInterface } = require('screwdriver-build-bookend');
+
 const ARTIFACTS_DIR_SUFFIX = 'ARTIFACTS';
+const COMMANDS = fs.readFileSync(path.join(__dirname, 'commands.txt'), 'utf8').trim();
 
 class ArtifactBookend extends BookendInterface {
     /**
@@ -13,13 +17,10 @@ class ArtifactBookend extends BookendInterface {
     constructor(storeUrl) {
         super();
         this.storeUrl = storeUrl;
-        this.teardownCommands = [
-            'cd $SD_ARTIFACTS_DIR',
-            'find . -print > manifest.txt',
-            'find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" ' +
-            '-H "Content-Type: text/plain" -X ' +
-            `PUT ${this.storeUrl}/v1/builds/$SD_BUILD_ID/${ARTIFACTS_DIR_SUFFIX}/{} -T {} \\;`
-        ];
+        this.teardownCommands = COMMANDS
+             .replace('$ARTIFACTS_DIR_SUFFIX', ARTIFACTS_DIR_SUFFIX)
+             .replace('$STORE_URL', storeUrl)
+             .split('\n');
     }
 
     /**

--- a/test/data/commands.txt
+++ b/test/data/commands.txt
@@ -1,1 +1,1 @@
-cd $SD_ARTIFACTS_DIR && find . -print > manifest.txt && find . -name "*" -type f -exec curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/{} -T {} \;
+cd $SD_ARTIFACTS_DIR && find . -print > manifest.txt && find . -type f -exec sh -c 'f=${1/#\.\/}; curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/$f -T ./$f' -- {} \;


### PR DESCRIPTION
# Context

Few builds are found to have missing Artifacts in builds. On debugging it's happening because of how the PUT API to store is being called

170822/220329.479, [response,api,builds] https://store.screwdriver.cd: put /v1/builds/4710/ARTIFACTS/steps.json {} 202 (185ms)


170822/213848.121, [response,api,builds] https://store.screwdriver.cd: put /v1/builds/4702/ARTI**FACTS/./steps.js**on {} 202 (389ms)


There is an extra **./** in certain file uploads, which is consistent with how file returns a file name when you do a `find .`

# Objective

This PR strips of leading **./** from file name before putting the file name in URL

Escaping shell commands in JS is hard and error prone, so I am moving it to a file which this bookend will read.

@minz1027 @d2lam 