### PR TITLE
fix: remove empty dir from manifest

### DIFF
--- a/commands.txt
+++ b/commands.txt
@@ -1,3 +1,3 @@
 cd $SD_ARTIFACTS_DIR
-find . -print > manifest.txt
+find . -type f -print > manifest.txt
 find . -type f -exec sh -c 'f=`echo $1 | sed "s/^\.\///"`; curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT $STORE_URL/v1/builds/$SD_BUILD_ID/$ARTIFACTS_DIR_SUFFIX/$f -T ./$f' -- {} \;

--- a/test/data/commands.txt
+++ b/test/data/commands.txt
@@ -1,1 +1,1 @@
-cd $SD_ARTIFACTS_DIR && find . -print > manifest.txt && find . -type f -exec sh -c 'f=`echo $1 | sed "s/^\.\///"`; curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/$f -T ./$f' -- {} \;
+cd $SD_ARTIFACTS_DIR && find . -type f -print > manifest.txt && find . -type f -exec sh -c 'f=`echo $1 | sed "s/^\.\///"`; curl -H "Authorization: Bearer $SD_TOKEN" -H "Content-Type: text/plain" -X PUT https://store.screwdriver.cd/v1/builds/$SD_BUILD_ID/ARTIFACTS/$f -T ./$f' -- {} \;


### PR DESCRIPTION
 remove empty dir from `manifest` because UI will treat empty dir as file and that's confusing.