### PR TITLE
fix: Update to use new workflow

### DIFF
--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -1,16 +1,15 @@
-workflow:
-    - publish
-
 shared:
     image: node:6
 
 jobs:
     main:
+        requires: [~pr, ~commit]
         steps:
             - install: npm install
             - test: npm test
 
     publish:
+        requires: [main]
         template: screwdriver-cd/semantic-release 
         secrets:
             # Publishing to NPM


### PR DESCRIPTION
## Context
The last PR https://github.com/screwdriver-cd/artifact-bookend/pull/10 has failed to publish because of semantic release.
So, I opened PR again and fixed `screwdriver.yaml` to use new workflow at the same time.

## Reference
The last PR: https://github.com/screwdriver-cd/artifact-bookend/pull/10
