### PR TITLE
fix: Remove noop plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,9 @@
     "screwdriver-build-bookend": "^2.3.3"
   },
   "release": {
+    "branches": [
+      "master"
+    ],
     "debug": false
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com:screwdriver-cd/artifact-bookend.git"
+    "url": "git+https://github.com/screwdriver-cd/artifact-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/artifact-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "pretest": "eslint .",
     "test": "nyc --report-dir ./artifacts/coverage --reporter=lcov mocha --reporter mocha-multi-reporters --reporter-options configFile=./mocha.config.json --recursive --timeout 4000 --retries 1 --exit --allow-uncaught true --color true",
-    "semantic-release": "semantic-release pre && npm publish && semantic-release post"
+    "semantic-release": "./node_modules/.bin/semantic-release"
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:screwdriver-cd/artifact-bookend.git"
+    "url": "git+https://github.com:screwdriver-cd/artifact-bookend.git"
   },
   "homepage": "https://github.com/screwdriver-cd/artifact-bookend",
   "bugs": "https://github.com/screwdriver-cd/screwdriver/issues",
@@ -42,9 +42,6 @@
     "screwdriver-build-bookend": "^2.3.3"
   },
   "release": {
-    "debug": false,
-    "verifyConditions": {
-      "path": "./node_modules/semantic-release/src/lib/plugin-noop.js"
-    }
+    "debug": false
   }
 }


### PR DESCRIPTION
## Context
Seeing Error: `Cannot find module './node_modules/semantic-release/src/lib/plugin-noop.js'`


<!-- Why do we need this PR? What was the reason that led you to make this change? -->

## Objective
Removes old package.json section for noop plugin
<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
