### PR TITLE
feat(2763): upgrade build-bookend module version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "nyc": "^15.0.0"
   },
   "dependencies": {
-    "screwdriver-build-bookend": "^2.3.3"
+    "screwdriver-build-bookend": "^3.0.0"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->

`screwdriver-build-bookend@v3.0.0` has released.

https://github.com/screwdriver-cd/build-bookend/pull/22

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

This PR upgrade `screwdriver-build-bookend` module version.
There are no changes to `BookendInterface` with [this upgrade](https://github.com/screwdriver-cd/build-bookend/compare/v2.4.0...v3.0.0).

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

https://cd.screwdriver.cd/pipelines/1/builds/827090/steps/duplicate

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
